### PR TITLE
fix: Copy code doesn't work itself at root of webapp.

### DIFF
--- a/app/components/playground.tsx
+++ b/app/components/playground.tsx
@@ -17,9 +17,11 @@ const Playground: React.FC<PlaygroundProps> = ({
 }) => {
   const copyCode = () => {
     const code = ReactDOMServer.renderToString(children);
+    const prefix = '<div class="fixed left-0 top-0 -z-10 h-full w-full">'
+    const postfix = '</div>'
+    navigator.clipboard.writeText(prefix + code + postfix);
+    toast.success('Copied to clipboard. Paste code at root of you web app to see the background effect.');
 
-    navigator.clipboard.writeText(code);
-    toast.success('Copied to clipboard');
   };
 
   return (


### PR DESCRIPTION
### Issue
When you use the code given by copy code button it doesn't work as expected when placing it in your webapp. It needs to be wrapped in : 
```
<div className="fixed left-0 top-0 -z-10 h-full w-full">
         #COPY CODE HERE
 </div>
```

and then placed.

So added a small fix for that. 