### PR TITLE
`Fix` duplication of meta tags in layout.tsx and enhance head management

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,11 +6,14 @@ const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
   title: 'BG.IBELICK - Modern, Ready-to-Use Background Snippets for Developers',
-  description: 'A collection of modern background snippets for web developers. Ready-to-use snippets crafted with Tailwind CSS and Vanilla CSS for seamless integration.',
-  keywords: 'background snippets, Tailwind CSS, CSS snippets, web development, front-end snippets, free CSS resources',
+  description:
+    'A collection of modern background snippets for web developers. Ready-to-use snippets crafted with Tailwind CSS and Vanilla CSS for seamless integration.',
+  keywords:
+    'background snippets, Tailwind CSS, CSS snippets, web development, front-end snippets, free CSS resources',
   openGraph: {
     title: 'BG.IBELICK - Ready-to-Use Background Snippets',
-    description: 'Modern background snippets for web developers crafted with Tailwind CSS and Vanilla CSS.',
+    description:
+      'Modern background snippets for web developers crafted with Tailwind CSS and Vanilla CSS.',
     url: 'https://bg.ibelick.com',
     type: 'website',
     images: [
@@ -25,7 +28,8 @@ export const metadata = {
   twitter: {
     card: 'summary_large_image',
     title: 'BG.IBELICK - Ready-to-Use Background Snippets',
-    description: 'Modern background snippets for web developers crafted with Tailwind CSS and Vanilla CSS.',
+    description:
+      'Modern background snippets for web developers crafted with Tailwind CSS and Vanilla CSS.',
     image: '/banner.jpg',
   },
 };
@@ -38,36 +42,17 @@ export default function RootLayout({
   const isDev = process.env.NODE_ENV === 'development';
 
   return (
-    <html lang="en">
-      <head>
-        <title>{metadata.title}</title>
-        <meta name="description" content={metadata.description} />
-        <meta name="keywords" content={metadata.keywords} />
-        
-        {/* Open Graph Metadata */}
-        <meta property="og:title" content={metadata.openGraph.title} />
-        <meta property="og:description" content={metadata.openGraph.description} />
-        <meta property="og:url" content={metadata.openGraph.url} />
-        <meta property="og:type" content={metadata.openGraph.type} />
-        <meta property="og:image" content={metadata.openGraph.images[0].url} />
-        <meta property="og:image:alt" content={metadata.openGraph.images[0].alt} />
-        <meta property="og:image:width" content={metadata.openGraph.images[0].width.toString()} />
-        <meta property="og:image:height" content={metadata.openGraph.images[0].height.toString()} />
-
-        {/* Twitter Card Metadata */}
-        <meta name="twitter:card" content={metadata.twitter.card} />
-        <meta name="twitter:title" content={metadata.twitter.title} />
-        <meta name="twitter:description" content={metadata.twitter.description} />
-        <meta name="twitter:image" content={metadata.twitter.image} />
-      </head>
-      {!isDev ? (
-        <Script
-          async
-          src="https://analytics.umami.is/script.js"
-          data-website-id="9ad0e597-9fa4-4690-8ca2-18a964ab087f"
-        />
-      ) : null}
-      <body className={inter.className}>{children}</body>
+    <html lang="en" className={inter.className}>
+      <body>
+        {!isDev ? (
+          <Script
+            async
+            src="https://analytics.umami.is/script.js"
+            data-website-id="9ad0e597-9fa4-4690-8ca2-18a964ab087f"
+          />
+        ) : null}
+        {children}
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
This PR addresses the duplication of meta tags and `<title>` in the `layout.tsx` file by removing the manual addition of these elements and relying on Next.js's automatic injection via the exported `metadata` object. The HTML structure has been cleaned up, and consistent use of the `inter` font class has been applied to the `<html>` element for better maintainability.

### Changes:
- Removed manually added `<meta>` tags and `<title>` from `layout.tsx` to avoid duplication.
- Applied the `inter` font class directly to the `<html>` element for consistency.
- Ensured cleaner, more production-ready HTML structure.
- Placed the `Script` component from `next/script` inside the `<body>` tag for optimal loading.

Please review the changes and let me know if any further adjustments are needed.

![image](https://github.com/user-attachments/assets/82466e7b-e68d-44e4-8a9f-8682e25bc5ae)

